### PR TITLE
简化诱饵弹砸人，原图作者是想卡雷的人按中间的按钮没收武器再去其他按钮获得诱饵弹，但这样会对不懂的萌新卡雷了不公平，改成所有按钮都以会没收所…

### DIFF
--- a/stripper/mg_Rank_Multigames_Final_Fix.cfg
+++ b/stripper/mg_Rank_Multigames_Final_Fix.cfg
@@ -1,0 +1,59 @@
+modify:
+{
+	match:
+	{
+		"classname" "func_button"
+		"targetname" "decoy_game_spawner"
+	}
+	delete:
+	{
+		"OnPressed" "dc_spawneruse!activator0-1"
+		"OnPressed" "dc_spawneruse!activator0.5-1"
+	}
+	insert:
+	{
+		"OnPressed" "dc_spawner2use!activator0-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "func_button"
+		"targetname" "decoy_game_spawner2"
+	}
+	delete:
+	{
+		"OnPressed" "no_equip2use!activator0-1"
+		"OnPressed" "no_equip2use!activator0.5-1"
+	}
+	insert:
+	{
+		"OnPressed" "dc_spawner2use!activator0-1"
+	}
+}
+
+add:
+{
+	{
+	"classname" "game_player_equip"
+	"spawnflags" "3"
+	"targetname" "dc_spawner2"
+	"weapon_decoy" "1"
+	"origin" "-2040 -808 186"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "func_button"
+		"targetnamename "decoy_game_vote"
+	}
+	insert:
+	{
+		"OnPressed" "dc_spawner2AddOutputspawnflags 175-1"
+	}
+}


### PR DESCRIPTION
…有武器的前提下发诱饵弹以防止卡雷，在到时间发刀的时候更改发诱饵弹的实体为只发诱饵弹而不没收武器。