### PR TITLE
删除一个bug模型 禁止一个模型挂墙

### DIFF
--- a/prophurt/de_bank.cfg
+++ b/prophurt/de_bank.cfg
@@ -20,10 +20,6 @@
 	{
 		"en"		"货架柜"
 	}
-	"props/de_vostok/counter_generalstore"
-	{
-		"en"		"桌子"
-	}
 	"props/cs_office/tv_plasma"
 	{
 		"special"		"1"
@@ -510,7 +506,6 @@
 	"props_doors\roll-up_door_full"
 	{
 		"en"		"卷帘门"
-		"special"		"1"
 	}
 	"props_exteriors\guardrail512"
 	{


### PR DESCRIPTION
桌子的可视部分可以整个卡进墙里 故删除
卷帘门挂墙只露顶 故禁止挂墙