### PR TITLE
添加地图总时间设置

### DIFF
--- a/mapcfg/bili27_pack.cfg
+++ b/mapcfg/bili27_pack.cfg
@@ -1,0 +1,1 @@
+mp_timelimit 32


### PR DESCRIPTION
地图原本的时长为45 比其他躲猫猫图的时间(32)都要长
通常12回合过后 不论萌新还是老玩家都会觉得这张图打腻了，同一张图时间太长不容易留住玩家
故改为和猫服其他图一致的32分钟