### PR TITLE
删除bug模型、补充模型命名

### DIFF
--- a/prophurt/prophurt_downtown.cfg
+++ b/prophurt/prophurt_downtown.cfg
@@ -499,7 +499,7 @@
 	}
 		"props_urban\hotel_halfmoon_table001"
 	{
-		"en"		"props_urban\hotel_halfmoon_table001"
+		"en"		"半圆桌"
 	}
 	"props\gg_tibet\ornatecart"
 	{
@@ -511,15 +511,11 @@
 	}
 	"props_equipment\gas_pump"
 	{
-		"en"		"props_equipment\gas_pump"
+		"en"		"加油站"
 	}
 	"props_doors\roll-up_door_full"
 	{
 		"en"		"卷帘门"
-	}
-	"props\de_burger\de_burger_signgasstation01"
-	{
-		"en"		"标识牌-巨大"
 	}
 	"props_vehicles\semi_trailer"
 	{
@@ -527,11 +523,11 @@
 	}
 	"props_street\flagpole"
 	{
-		"en"		"国旗"
+		"en"		"国旗1"
 	}
 	"props_fairgrounds\fairgrounds_flagpole01"
 	{
-		"en"		"props_fairgrounds\fairgrounds_flagpole01"
+		"en"		"国旗2"
 	}
 }
 //


### PR DESCRIPTION
"标识牌-巨大"可以完全藏进楼梯间门框的墙体，在这种位置锁定后既看不见又打不到，故删除